### PR TITLE
feature/response page

### DIFF
--- a/src/pages/Response/components/ResponseItem.tsx
+++ b/src/pages/Response/components/ResponseItem.tsx
@@ -8,7 +8,7 @@ type TProps = {
 
 const ResponseItem: React.FC<TProps> = ({ response }) => {
   return (
-    <div className="h-[250px] p-4 bg-gray-50 border shadow-sm rounded flex flex-col">
+    <div className="h-[250px] p-4 bg-gray-50 border shadow-sm rounded flex flex-col hover:bg-gray-100 hover:-translate-y-1 transition-all duration-200">
       {/* Username Container */}
       <div>
         <span className="text-lg font-bold">{response.username}</span>
@@ -19,13 +19,13 @@ const ResponseItem: React.FC<TProps> = ({ response }) => {
       </div>
       {/* Actions Container */}
       <div className="justify-end self-end flex flex-row gap-2">
-        <button className="bg-gray-200 h-10 w-10 rounded-full aspect-square">
+        <button className="bg-gray-200 h-10 w-10 rounded-full aspect-square hover:bg-gray-300 hover:border hover:border-gray-500 transition-all duration-200">
           🤸🏽
         </button>
-        <button className="bg-gray-200 h-10 w-10 rounded-full aspect-square">
+        <button className="bg-gray-200 h-10 w-10 rounded-full aspect-square hover:bg-gray-300 hover:border hover:border-gray-500 transition-all duration-200">
           ✨
         </button>
-        <button className="bg-gray-200 h-10 w-10 rounded-full aspect-square">
+        <button className="bg-gray-200 h-10 w-10 rounded-full aspect-square hover:bg-gray-300 hover:border hover:border-gray-500 transition-all duration-200">
           ❌
         </button>
       </div>

--- a/src/pages/Response/components/ResponseItem.tsx
+++ b/src/pages/Response/components/ResponseItem.tsx
@@ -1,0 +1,36 @@
+type TProps = {
+  response: {
+    id: number;
+    username: string;
+    message: string;
+  };
+};
+
+const ResponseItem: React.FC<TProps> = ({ response }) => {
+  return (
+    <div className="h-[250px] p-4 bg-gray-50 border shadow-sm rounded flex flex-col">
+      {/* Username Container */}
+      <div>
+        <span className="text-lg font-bold">{response.username}</span>
+      </div>
+      {/* Beshified Text Container */}
+      <div className="flex-grow">
+        <span className="text-md">{response.message}</span>
+      </div>
+      {/* Actions Container */}
+      <div className="justify-end self-end flex flex-row gap-2">
+        <button className="bg-gray-200 h-10 w-10 rounded-full aspect-square">
+          🤸🏽
+        </button>
+        <button className="bg-gray-200 h-10 w-10 rounded-full aspect-square">
+          ✨
+        </button>
+        <button className="bg-gray-200 h-10 w-10 rounded-full aspect-square">
+          ❌
+        </button>
+      </div>
+    </div>
+  );
+};
+
+export default ResponseItem;

--- a/src/pages/Response/components/ResponseItem.tsx
+++ b/src/pages/Response/components/ResponseItem.tsx
@@ -2,7 +2,7 @@ type TProps = {
   response: {
     id: number;
     username: string;
-    message: string;
+    statement: string;
   };
 };
 
@@ -15,7 +15,7 @@ const ResponseItem: React.FC<TProps> = ({ response }) => {
       </div>
       {/* Beshified Text Container */}
       <div className="flex-grow">
-        <span className="text-md">{response.message}</span>
+        <span className="text-md">{response.statement}</span>
       </div>
       {/* Actions Container */}
       <div className="justify-end self-end flex flex-row gap-2">

--- a/src/pages/Response/index.tsx
+++ b/src/pages/Response/index.tsx
@@ -32,8 +32,21 @@ const Response = () => {
           </div>
         ))}
       </div>
-      <div className="p-5">
+      <div className="p-5 row-span-2">
         <ChatBox />
+      </div>
+      {/* Voting Timer Container */}
+      <div className="col-span-2 p-5">
+        <span className="text-lg font-bold block">Voting Timer</span>
+        <div className="flex flex-row">
+          <div className="bg-black text-white text-3xl p-1 rounded font-bold">
+            <span>00</span>
+          </div>
+          <span className="text-3xl font-bold">:</span>
+          <div className="bg-black text-white text-3xl p-1 rounded font-bold">
+            <span>00</span>
+          </div>
+        </div>
       </div>
     </div>
   );

--- a/src/pages/Response/index.tsx
+++ b/src/pages/Response/index.tsx
@@ -27,30 +27,35 @@ const Response = () => {
   }, [seconds]);
 
   return (
-    <div className="h-[calc(100vh-74px)] grid grid-cols-3 p-1 mx-40">
-      <div className="col-span-2 grid grid-flow-row grid-cols-2 gap-4 overflow-y-auto p-10 relative">
-        {DUMMY_RESPONSES.map((response) => (
-          <ResponseItem key={response.id} response={response} />
-        ))}
-      </div>
-      <div className="p-5 row-span-2">
-        <ChatBox />
-      </div>
-      {/* Voting Timer Container */}
-      <div className="col-span-2 p-5">
-        <span className="text-lg font-bold block">Voting Timer</span>
-        <div className="flex flex-row">
-          <div className="bg-black text-white text-3xl p-1 rounded font-bold">
-            <span>00</span>
-          </div>
-          <span className="text-3xl font-bold">:</span>
-          <div className="bg-black text-white text-3xl p-1 rounded font-bold">
-            <span>
-              {
-                // Format seconds to 2 digits
-                seconds.toString().padStart(2, "0")
-              }
-            </span>
+    <div className="">
+      <div className="md:container md:mx-auto h-[calc(100vh-74px)] grid grid-cols-3 p-2">
+        <div className="col-span-2 grid grid-flow-row grid-cols-1 lg:grid-cols-2 gap-4 overflow-y-auto p-10 relative">
+          {DUMMY_RESPONSES.map((response) => (
+            <ResponseItem key={response.id} response={response} />
+          ))}
+        </div>
+        <div className="p-5 row-span-2">
+          <h1 className="font-bold text-center text-3xl py-5">
+            ✨Vote na mga Beshie!✨
+          </h1>
+          <ChatBox />
+        </div>
+        {/* Voting Timer Container */}
+        <div className="col-span-2 p-3">
+          <span className="text-lg font-bold block">Voting Timer</span>
+          <div className="flex flex-row">
+            <div className="bg-black text-white text-3xl p-1 rounded font-bold">
+              <span>00</span>
+            </div>
+            <span className="text-3xl font-bold">:</span>
+            <div className="bg-black text-white text-3xl p-1 rounded font-bold">
+              <span>
+                {
+                  // Format seconds to 2 digits
+                  seconds.toString().padStart(2, "0")
+                }
+              </span>
+            </div>
           </div>
         </div>
       </div>

--- a/src/pages/Response/index.tsx
+++ b/src/pages/Response/index.tsx
@@ -1,5 +1,127 @@
+import ChatBox from "../../components/ChatBox";
+
 const Response = () => {
-  return <div>Response</div>;
+  return (
+    <div className="h-[calc(100vh-74px)] grid grid-cols-3 p-1 mx-40">
+      <div className="col-span-2 grid grid-flow-row grid-cols-2 gap-4 overflow-y-auto p-10 relative">
+        {DUMMY_RESPONSES.map((response) => (
+          <div
+            key={response.id}
+            className="h-[250px] p-4 bg-gray-50 border shadow-sm rounded flex flex-col"
+          >
+            {/* Username Container */}
+            <div>
+              <span className="text-lg font-bold">{response.username}</span>
+            </div>
+            {/* Beshified Text Container */}
+            <div className="flex-grow">
+              <span className="text-md">{response.message}</span>
+            </div>
+            {/* Actions Container */}
+            <div className="justify-end self-end flex flex-row gap-2">
+              <button className="bg-gray-200 h-10 w-10 rounded-full aspect-square">
+                🤸🏽
+              </button>
+              <button className="bg-gray-200 h-10 w-10 rounded-full aspect-square">
+                ✨
+              </button>
+              <button className="bg-gray-200 h-10 w-10 rounded-full aspect-square">
+                ❌
+              </button>
+            </div>
+          </div>
+        ))}
+      </div>
+      <div className="p-5">
+        <ChatBox />
+      </div>
+    </div>
+  );
 };
 
 export default Response;
+
+const DUMMY_RESPONSES = [
+  {
+    id: 1,
+    username: "Beshy1",
+    message: "Hello🤸🏽Beshy!",
+  },
+  {
+    id: 2,
+    username: "Beshy2",
+    message: "What's🤸🏽up🤸🏽Beshy!",
+  },
+  {
+    id: 3,
+    username: "Beshy3",
+    message: "Good🤸🏽morning🤸🏽Beshy!",
+  },
+  {
+    id: 4,
+    username: "Beshy4",
+    message:
+      "Hey🤸🏽Beshy,🤸🏽have🤸🏽you🤸🏽tried🤸🏽out🤸🏽the🤸🏽new🤸🏽VS🤸🏽Code🤸🏽extension?🤸🏽",
+  },
+  {
+    id: 5,
+    username: "Beshy5",
+    message: "Hi🤸🏽Beshy,🤸🏽what's🤸🏽your🤸🏽favorite🤸🏽programming🤸🏽language?🤸🏽",
+  },
+  {
+    id: 6,
+    username: "Beshy6",
+    message:
+      "What's🤸🏽good🤸🏽Beshy,🤸🏽have🤸🏽you🤸🏽seen🤸🏽the🤸🏽latest🤸🏽tech🤸🏽news?🤸🏽",
+  },
+  {
+    id: 7,
+    username: "Beshy7",
+    message:
+      "Hey🤸🏽Beshy,🤸🏽do🤸🏽you🤸🏽have🤸🏽any🤸🏽exciting🤸🏽projects🤸🏽you're🤸🏽working🤸🏽on?🤸🏽",
+  },
+  {
+    id: 8,
+    username: "Beshy8",
+    message: "Good🤸🏽afternoon🤸🏽Beshy,🤸🏽how's🤸🏽your🤸🏽day🤸🏽been🤸🏽so🤸🏽far?🤸🏽",
+  },
+  {
+    id: 9,
+    username: "Beshy9",
+    message:
+      "What's🤸🏽up🤸🏽Beshy,🤸🏽have🤸🏽you🤸🏽tried🤸🏽out🤸🏽the🤸🏽new🤸🏽CSS🤸🏽framework?🤸🏽",
+  },
+  {
+    id: 10,
+    username: "Beshy10",
+    message: "Hey🤸🏽Beshy,🤸🏽what's🤸🏽your🤸🏽favorite🤸🏽coding🤸🏽playlist?🤸🏽",
+  },
+  {
+    id: 11,
+    username: "Beshy5",
+    message: "Hi🤸🏽Beshy,🤸🏽what's🤸🏽your🤸🏽favorite🤸🏽programming🤸🏽language?🤸🏽",
+  },
+  {
+    id: 12,
+    username: "Beshy6",
+    message:
+      "What's🤸🏽good🤸🏽Beshy,🤸🏽have🤸🏽you🤸🏽seen🤸🏽the🤸🏽latest🤸🏽tech🤸🏽news?🤸🏽",
+  },
+  {
+    id: 13,
+    username: "Beshy7",
+    message:
+      "Hey🤸🏽Beshy,🤸🏽do🤸🏽you🤸🏽have🤸🏽any🤸🏽exciting🤸🏽projects🤸🏽you're🤸🏽working🤸🏽on?🤸🏽",
+  },
+  {
+    id: 14,
+    username: "Beshy8",
+    message: "Good🤸🏽afternoon🤸🏽Beshy,🤸🏽how's🤸🏽your🤸🏽day🤸🏽been🤸🏽so🤸🏽far?🤸🏽",
+  },
+  {
+    id: 15,
+    username: "Beshy9",
+    message:
+      "What's🤸🏽up🤸🏽Beshy,🤸🏽have🤸🏽you🤸🏽tried🤸🏽out🤸🏽the🤸🏽new🤸🏽CSS🤸🏽framework?🤸🏽",
+  },
+];

--- a/src/pages/Response/index.tsx
+++ b/src/pages/Response/index.tsx
@@ -7,24 +7,31 @@ const Response = () => {
   // const navigate = useNavigate();
   // const { id } = useParams();
   const [seconds, setSeconds] = useState(5);
+  const [minutes, setMinutes] = useState(1);
 
   useEffect(() => {
     // Simulate countdown timer for voting
     const interval = setInterval(() => {
-      setSeconds((seconds) => seconds - 1);
+      if (seconds === 0 && minutes > 0) {
+        setSeconds(59);
+        setMinutes(minutes - 1);
+      } else {
+        setSeconds(seconds - 1);
+      }
     }, 1000);
 
     // Navigate to showcase page if the countdown timer reaches 0
-    if (seconds === 0) {
-      console.log("Time's up! Navigate to showcase page.");
+    if (seconds === 0 && minutes === 0) {
+      console.log("Voting has ended!");
+      clearInterval(interval);
 
       // TODO: Uncomment this and other related lines when showcase page is ready
       // navigate(`/beshify/showcase/${id}`);
 
-      clearInterval(interval);
+      return;
     }
     return () => clearInterval(interval);
-  }, [seconds]);
+  }, [seconds, minutes]);
 
   return (
     <div className="">
@@ -45,7 +52,7 @@ const Response = () => {
           <span className="text-lg font-bold block">Voting Timer</span>
           <div className="flex flex-row">
             <div className="bg-black text-white text-3xl p-1 rounded font-bold">
-              <span>00</span>
+              <span>{minutes.toString().padStart(2, "0")}</span>
             </div>
             <span className="text-3xl font-bold">:</span>
             <div className="bg-black text-white text-3xl p-1 rounded font-bold">

--- a/src/pages/Response/index.tsx
+++ b/src/pages/Response/index.tsx
@@ -1,7 +1,31 @@
+import { useEffect, useState } from "react";
 import ChatBox from "../../components/ChatBox";
 import ResponseItem from "./components/ResponseItem";
+// import { useNavigate, useParams } from "react-router-dom";
 
 const Response = () => {
+  // const navigate = useNavigate();
+  // const { id } = useParams();
+  const [seconds, setSeconds] = useState(5);
+
+  useEffect(() => {
+    // Simulate countdown timer for voting
+    const interval = setInterval(() => {
+      setSeconds((seconds) => seconds - 1);
+    }, 1000);
+
+    // Navigate to showcase page if the countdown timer reaches 0
+    if (seconds === 0) {
+      console.log("Time's up! Navigate to showcase page.");
+
+      // TODO: Uncomment this and other related lines when showcase page is ready
+      // navigate(`/beshify/showcase/${id}`);
+
+      clearInterval(interval);
+    }
+    return () => clearInterval(interval);
+  }, [seconds]);
+
   return (
     <div className="h-[calc(100vh-74px)] grid grid-cols-3 p-1 mx-40">
       <div className="col-span-2 grid grid-flow-row grid-cols-2 gap-4 overflow-y-auto p-10 relative">
@@ -21,7 +45,12 @@ const Response = () => {
           </div>
           <span className="text-3xl font-bold">:</span>
           <div className="bg-black text-white text-3xl p-1 rounded font-bold">
-            <span>00</span>
+            <span>
+              {
+                // Format seconds to 2 digits
+                seconds.toString().padStart(2, "0")
+              }
+            </span>
           </div>
         </div>
       </div>

--- a/src/pages/Response/index.tsx
+++ b/src/pages/Response/index.tsx
@@ -1,35 +1,12 @@
 import ChatBox from "../../components/ChatBox";
+import ResponseItem from "./components/ResponseItem";
 
 const Response = () => {
   return (
     <div className="h-[calc(100vh-74px)] grid grid-cols-3 p-1 mx-40">
       <div className="col-span-2 grid grid-flow-row grid-cols-2 gap-4 overflow-y-auto p-10 relative">
         {DUMMY_RESPONSES.map((response) => (
-          <div
-            key={response.id}
-            className="h-[250px] p-4 bg-gray-50 border shadow-sm rounded flex flex-col"
-          >
-            {/* Username Container */}
-            <div>
-              <span className="text-lg font-bold">{response.username}</span>
-            </div>
-            {/* Beshified Text Container */}
-            <div className="flex-grow">
-              <span className="text-md">{response.message}</span>
-            </div>
-            {/* Actions Container */}
-            <div className="justify-end self-end flex flex-row gap-2">
-              <button className="bg-gray-200 h-10 w-10 rounded-full aspect-square">
-                🤸🏽
-              </button>
-              <button className="bg-gray-200 h-10 w-10 rounded-full aspect-square">
-                ✨
-              </button>
-              <button className="bg-gray-200 h-10 w-10 rounded-full aspect-square">
-                ❌
-              </button>
-            </div>
-          </div>
+          <ResponseItem key={response.id} response={response} />
         ))}
       </div>
       <div className="p-5 row-span-2">


### PR DESCRIPTION
Hello!

This PR adds the Response page based on the layout from figma. Here are some of the changes I've made:

- Created dummy responses data to showcase the layout effectively.
- Created the `ResponseItem` component to handle individual response data
- Implemented a simulated countdown timer for voting that updates every second. You can change the duration of the timer in the `useState()` declaration minutes and seconds.
- To prepare for the Showcase Page, I temporarily commented out the `navigate()` function when the timer runs out. Once the Showcase Page is ready, these lines can be uncommented to enable automatic redirection at the end of the countdown.
- Added subtle hover effects to each Response Item and their action buttons.

 I've tested the new functionality, and everything appears to be working as expected.